### PR TITLE
Add default for bnormal_aux function

### DIFF
--- a/Exec/Efield/FlameSheetIons/pelelmex_prob.H
+++ b/Exec/Efield/FlameSheetIons/pelelmex_prob.H
@@ -211,25 +211,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Efield/IonizedAirWave/pelelmex_prob.H
+++ b/Exec/Efield/IonizedAirWave/pelelmex_prob.H
@@ -156,25 +156,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Efield/PremBunsen3DKuhl/pelelmex_prob.H
+++ b/Exec/Efield/PremBunsen3DKuhl/pelelmex_prob.H
@@ -215,25 +215,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/ChallengeProblem/pelelmex_prob.H
+++ b/Exec/Production/ChallengeProblem/pelelmex_prob.H
@@ -355,25 +355,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/CounterFlow/pelelmex_prob.H
+++ b/Exec/Production/CounterFlow/pelelmex_prob.H
@@ -229,25 +229,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/CounterFlowSpray/pelelmex_prob.H
+++ b/Exec/Production/CounterFlowSpray/pelelmex_prob.H
@@ -217,25 +217,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/DiffBunsen2D/pelelmex_prob.H
+++ b/Exec/Production/DiffBunsen2D/pelelmex_prob.H
@@ -288,25 +288,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/JetInCrossflow/pelelmex_prob.H
+++ b/Exec/Production/JetInCrossflow/pelelmex_prob.H
@@ -262,25 +262,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.H
+++ b/Exec/Production/NormalJet_OpenDomain/pelelmex_prob.H
@@ -134,25 +134,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/PremBunsen2D/pelelmex_prob.H
+++ b/Exec/Production/PremBunsen2D/pelelmex_prob.H
@@ -196,25 +196,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/PremBunsen3D/pelelmex_prob.H
+++ b/Exec/Production/PremBunsen3D/pelelmex_prob.H
@@ -183,25 +183,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/Production/SwirlFlowWallInteractions/pelelmex_prob.H
+++ b/Exec/Production/SwirlFlowWallInteractions/pelelmex_prob.H
@@ -569,25 +569,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int /*i*/,
   int /*j*/,

--- a/Exec/Production/TripleFlame/pelelmex_prob.H
+++ b/Exec/Production/TripleFlame/pelelmex_prob.H
@@ -173,25 +173,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/EB_BackwardStepFlame/pelelmex_prob.H
+++ b/Exec/RegTests/EB_BackwardStepFlame/pelelmex_prob.H
@@ -123,25 +123,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/EB_EnclosedFlame/pelelmex_prob.H
+++ b/Exec/RegTests/EB_EnclosedFlame/pelelmex_prob.H
@@ -137,25 +137,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/EB_EnclosedVortex/pelelmex_prob.H
+++ b/Exec/RegTests/EB_EnclosedVortex/pelelmex_prob.H
@@ -101,25 +101,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/EB_FlowPastCylinder/pelelmex_prob.H
+++ b/Exec/RegTests/EB_FlowPastCylinder/pelelmex_prob.H
@@ -144,25 +144,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/EB_ODEQty/pelelmex_prob.H
+++ b/Exec/RegTests/EB_ODEQty/pelelmex_prob.H
@@ -184,25 +184,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/EB_PipeFlow/pelelmex_prob.H
+++ b/Exec/RegTests/EB_PipeFlow/pelelmex_prob.H
@@ -213,25 +213,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/EnclosedFlame/pelelmex_prob.H
+++ b/Exec/RegTests/EnclosedFlame/pelelmex_prob.H
@@ -139,25 +139,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int /*i*/,
   int /*j*/,

--- a/Exec/RegTests/EnclosedInjection/pelelmex_prob.H
+++ b/Exec/RegTests/EnclosedInjection/pelelmex_prob.H
@@ -125,25 +125,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/FlameSheet/pelelmex_prob.H
+++ b/Exec/RegTests/FlameSheet/pelelmex_prob.H
@@ -192,25 +192,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/HITDecay/pelelmex_prob.H
+++ b/Exec/RegTests/HITDecay/pelelmex_prob.H
@@ -184,25 +184,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int /*i*/,
   int /*j*/,

--- a/Exec/RegTests/HotBubble/pelelmex_prob.H
+++ b/Exec/RegTests/HotBubble/pelelmex_prob.H
@@ -100,25 +100,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/IsothermalSoretChannel/pelelmex_prob.H
+++ b/Exec/RegTests/IsothermalSoretChannel/pelelmex_prob.H
@@ -115,25 +115,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/PassiveScalar/pelelmex_prob.H
+++ b/Exec/RegTests/PassiveScalar/pelelmex_prob.H
@@ -102,6 +102,7 @@ bcnormal(
   // Periodic boundaries
 }
 
+#define PELE_CUSTOM_BCNORMAL_AUX
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void

--- a/Exec/RegTests/PeriodicCases/pelelmex_prob.H
+++ b/Exec/RegTests/PeriodicCases/pelelmex_prob.H
@@ -274,25 +274,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/SootRadTest/pelelmex_prob.H
+++ b/Exec/RegTests/SootRadTest/pelelmex_prob.H
@@ -120,25 +120,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/SprayTest/pelelmex_prob.H
+++ b/Exec/RegTests/SprayTest/pelelmex_prob.H
@@ -96,25 +96,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/TaylorGreen/pelelmex_prob.H
+++ b/Exec/RegTests/TaylorGreen/pelelmex_prob.H
@@ -93,25 +93,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/TripleFlame/pelelmex_prob.H
+++ b/Exec/RegTests/TripleFlame/pelelmex_prob.H
@@ -184,25 +184,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/TurbInflow/pelelmex_prob.H
+++ b/Exec/RegTests/TurbInflow/pelelmex_prob.H
@@ -135,25 +135,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/RegTests/Unit/pelelmex_prob.H
+++ b/Exec/RegTests/Unit/pelelmex_prob.H
@@ -183,23 +183,4 @@ bcnormal(
   }
 }
 
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
 #endif

--- a/Exec/UnitTests/DodecaneLu/pelelmex_prob.H
+++ b/Exec/UnitTests/DodecaneLu/pelelmex_prob.H
@@ -167,25 +167,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Exec/UnitTests/EB_SphericalFlame/pelelmex_prob.H
+++ b/Exec/UnitTests/EB_SphericalFlame/pelelmex_prob.H
@@ -133,25 +133,6 @@ bcnormal(
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-bcnormal_aux(
-  const amrex::Real x[AMREX_SPACEDIM],
-  amrex::CellData<amrex::Real>& aux_ext,
-  const int idir,
-  const int sgn,
-  const amrex::Real time,
-  amrex::GeometryData const& geomdata,
-  ProbParm const& prob_parm,
-  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
-{
-  amrex::ignore_unused(
-    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
-  // For filling auxiliary boundary conditions
-  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
-}
-
-AMREX_GPU_DEVICE
-AMREX_FORCE_INLINE
-void
 zero_visc(
   int i,
   int j,

--- a/Source/PeleLMeX_BCfill.H
+++ b/Source/PeleLMeX_BCfill.H
@@ -8,6 +8,27 @@
 
 using namespace amrex;
 
+#ifndef PELE_CUSTOM_BCNORMAL_AUX
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+void
+bcnormal_aux(
+  const amrex::Real x[AMREX_SPACEDIM],
+  amrex::CellData<amrex::Real>& aux_ext,
+  const int idir,
+  const int sgn,
+  const amrex::Real time,
+  amrex::GeometryData const& geomdata,
+  ProbParm const& prob_parm,
+  pele::physics::PMF::PmfData::DataContainer const* pmf_data)
+{
+  amrex::ignore_unused(
+    x, aux_ext, idir, sgn, time, geomdata, prob_parm, pmf_data);
+  // For filling auxiliary boundary conditions
+  // Retrieve nAux with aux_ext.ncomp, then aux_ext[n] = ...
+}
+#endif
+
 struct PeleLMCCFillExtDirState
 {
 


### PR DESCRIPTION
Uses macros to determine whether the custom or default function gets compiled. This is a bit ugly, but removes the need for users to add `bcnormal_aux` to all cases even when it is irrelevant. Really just meant to be a temporary solution to avoid a breaking change until we create better capability for adding new user-defined functions.