### PR TITLE
Fix auxiliary scalars with AMR

### DIFF
--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1140,6 +1140,8 @@ public:
   // FillCoarsePatch state components
   void fillcoarsepatch_state(
     int lev, amrex::Real a_time, amrex::MultiFab& a_state, int nGhost);
+  void fillcoarsepatch_aux(
+    int lev, amrex::Real a_time, amrex::MultiFab& a_aux, int nGhost);
   void fillcoarsepatch_divu(
     int lev, amrex::Real a_time, amrex::MultiFab& a_divu, int nGhost);
   void fillcoarsepatch_gradp(
@@ -1628,6 +1630,8 @@ public:
 
   LevelData*
   getLevelDataPtr(int lev, const PeleLM::TimeStamp& a_time, int useUmac = 0);
+  LevelData*
+  getLevelDataAuxPtr(int lev, const PeleLM::TimeStamp& a_time, int useUmac = 0);
   LevelDataReact* getLevelDataReactPtr(int lev);
 
   amrex::Real getTime(int lev, const PeleLM::TimeStamp& a_time) const

--- a/Source/PeleLMeX.cpp
+++ b/Source/PeleLMeX.cpp
@@ -63,6 +63,26 @@ PeleLM::getLevelDataPtr(
   return m_leveldata_floating.get();
 }
 
+PeleLM::LevelData*
+PeleLM::getLevelDataAuxPtr(
+  int lev, const PeleLM::TimeStamp& a_time, int /*useUMac*/)
+{
+  AMREX_ASSERT(
+    a_time == AmrOldTime || a_time == AmrNewTime || a_time == AmrHalfTime);
+  if (a_time == AmrOldTime) {
+    return m_leveldata_old[lev].get();
+  }
+  if (a_time == AmrNewTime) {
+    return m_leveldata_new[lev].get();
+  }
+  m_leveldata_floating = std::make_unique<LevelData>(
+    grids[lev], dmap[lev], *m_factory[lev], m_incompressible, m_has_divu,
+    m_nAux, m_nGrowState, m_use_soret, static_cast<int>(m_do_les));
+  Real time = getTime(lev, a_time);
+  fillpatch_aux(lev, time, m_leveldata_floating->state, 0, m_nGrowState);
+  return m_leveldata_floating.get();
+}
+
 PeleLM::LevelDataReact*
 PeleLM::getLevelDataReactPtr(int lev)
 {
@@ -358,8 +378,8 @@ void
 PeleLM::averageDownAux(const PeleLM::TimeStamp& a_time)
 {
   for (int lev = finest_level; lev > 0; --lev) {
-    auto* ldataFine_p = getLevelDataPtr(lev, a_time);
-    auto* ldataCrse_p = getLevelDataPtr(lev - 1, a_time);
+    auto* ldataFine_p = getLevelDataAuxPtr(lev, a_time);
+    auto* ldataCrse_p = getLevelDataAuxPtr(lev - 1, a_time);
 #ifdef AMREX_USE_EB
     EB_average_down(
       ldataFine_p->auxiliaries, ldataCrse_p->auxiliaries, 0, m_nAux,

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -848,6 +848,34 @@ PeleLM::fillcoarsepatch_state(
     0, refRatio(lev - 1), mapper, fetchBCRecArray(0, nCompState), 0);
 }
 
+// Fill the auxiliaries
+void
+PeleLM::fillcoarsepatch_aux(
+  int lev, const amrex::Real a_time, amrex::MultiFab& a_aux, int nGhost)
+{
+  AMREX_ASSERT(lev > 0);
+  ProbParm const* lprobparm = prob_parm_d;
+  auto const* lpmfdata = pmf_data.device_parm();
+
+
+  // Interpolator
+  auto* mapper = getInterpolator(m_regrid_interp_method);
+
+  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirAux>> crse_bndry_func(
+    geom[lev - 1], fetchBCRecAuxArray(0, m_nAux),
+    PeleLMCCFillExtDirAux{
+      lprobparm, lpmfdata, m_nAux});
+  PhysBCFunct<GpuBndryFuncFab<PeleLMCCFillExtDirAux>> fine_bndry_func(
+    geom[lev], fetchBCRecAuxArray(0, m_nAux),
+    PeleLMCCFillExtDirAux{
+      lprobparm, lpmfdata, m_nAux});
+  InterpFromCoarseLevel(
+    a_aux, IntVect(nGhost), a_time, m_leveldata_new[lev - 1]->auxiliaries, 0, 0,
+    m_nAux, geom[lev - 1], geom[lev], crse_bndry_func, 0, fine_bndry_func,
+    0, refRatio(lev - 1), mapper, fetchBCRecAuxArray(0, m_nAux), 0);
+
+}
+
 // Fill the grad P
 void
 PeleLM::fillcoarsepatch_gradp(

--- a/Source/PeleLMeX_Regrid.cpp
+++ b/Source/PeleLMeX_Regrid.cpp
@@ -348,6 +348,7 @@ PeleLM::MakeNewLevelFromCoarse(
 
   // Fill the leveldata_new
   fillcoarsepatch_state(lev, time, n_leveldata_new->state, m_nGrowState);
+  fillcoarsepatch_aux(lev, time, n_leveldata_new->auxiliaries, m_nGrowState);
   fillcoarsepatch_gradp(lev, time, n_leveldata_new->gp, 0);
   n_leveldata_new->press.setVal(0.0);
 
@@ -459,6 +460,7 @@ PeleLM::RemakeLevel(
 
   // Fill the leveldata_new
   fillpatch_state(lev, time, n_leveldata_new->state, m_nGrowState);
+  fillpatch_aux(lev, time, n_leveldata_new->auxiliaries, 0, m_nGrowState);
   fillpatch_gradp(lev, time, n_leveldata_new->gp, 0);
   n_leveldata_new->press.setVal(0.0);
 

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -413,7 +413,9 @@ PeleLM::readParameters()
       ppa.query("conservative", m_AdvTypeAux[n]);
       m_aux_Schmidt[n] = -1.0;
       ppa.query("Schmidt", m_aux_Schmidt[n]);
-      if (m_aux_Schmidt[n] < 0) {
+      int diffuse = 1;
+      ppa.query("diffuse", diffuse);
+      if (diffuse == 0) {
         m_DiffTypeAux[n] = 0;
       } else {
         m_DiffTypeAux[n] = 1;

--- a/Source/PeleLMeX_TransportProp.cpp
+++ b/Source/PeleLMeX_TransportProp.cpp
@@ -342,7 +342,34 @@ PeleLM::calcDiffusivity(const TimeStamp& a_time)
         ldata_p->diff_aux_cc.mult(
           1.0 / m_aux_Schmidt[n], n, 1, ldata_p->diff_cc.nGrow());
       } else {
-        ldata_p->diff_aux_cc.setVal(0.0, n, 1);
+
+        // ldata_p->diff_aux_cc.setVal(0.0, n, 1);
+        MultiFab::Copy(
+          ldata_p->diff_aux_cc, ldata_p->diff_cc, NUM_SPECIES, n, 1,
+          ldata_p->diff_cc.nGrowVect()); // lambda
+
+        const auto& ba = ldata_p->diff_cc.boxArray();
+        const auto& dm = ldata_p->diff_cc.DistributionMap();
+        const auto& factory = ldata_p->diff_cc.Factory();
+
+        amrex::MultiFab cp_cc;
+        int ngrow = ldata_p->diff_cc.nGrow();
+        auto const* leosparm = eos_parms.device_parm();
+        cp_cc.define(ba, dm, 1, ngrow, MFInfo(), factory);
+        auto const& state_arr = ldata_p->state.const_arrays();
+        auto const& cp_arr = cp_cc.arrays();
+        amrex::ParallelFor(
+          cp_cc, cp_cc.nGrowVect(),
+          [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {
+            getCpmixGivenRYT(
+              i, j, k, Array4<Real const>(state_arr[box_no], DENSITY),
+              Array4<Real const>(state_arr[box_no], FIRSTSPEC),
+              Array4<Real const>(state_arr[box_no], TEMP),
+              Array4<Real>(cp_arr[box_no]), leosparm);
+          });
+
+        ldata_p->diff_aux_cc.divide(
+          cp_cc, n, 1, ldata_p->diff_cc.nGrow());
       }
     }
   }


### PR DESCRIPTION
This PR is to: 
- fix the issues related auxiliary variables not being initialized correctly when AMR is present in an inflow BC. 
- include the option for unity Lewis number. The Le=1 formulation is selected when `schmidt < 0` for a given scalar. A separate input variable `diffuse` was added to turn off diffusion. 

The issue with the auxiliary scalar was observed when AMR was added at the inflow BC. The code was returning "erroneous operation" for max_level = 2, and had non-physical values when max_level = 1. The first figure below shows the temperature contours for a jet issued from the inlet boundary at xlo and the boxes for level 1 at the boundary. An auxiliary scalar 'mixfrac' with inflow value equal to unity was added. This is a 3D case. The second figure clearly shows the non-physical behavior for the mixfrac field with very large values.

![plt00149_Slice_y_temp](https://github.com/user-attachments/assets/8df916d8-52d6-40f6-9afc-18642f73dde4)
![plt00149_Slice_y_mixfrac](https://github.com/user-attachments/assets/4561a7cf-0d31-4d44-8282-624a5f1a6b62)

The problem was mostly related to the regrid step and the fill patch for the auxiliary variables. The figure below shows the results produced with the code in this PR. 

max_level = 1
![plt00149_Slice_y_mixfrac](https://github.com/user-attachments/assets/ce08161f-0934-4983-8392-ab6960c37928)

max_level = 2
![plt00201_Slice_y_mixfrac](https://github.com/user-attachments/assets/ae3c76d0-78c7-425c-a136-cbdb95dcdd01)

The unity Le number implementation was also verified for the same test case that @ThomasHowarth used to test his implementation. The figure below shows the comparison between temperature, Le=1 and Sc=100 for data extracted from the domain centerline. 

<img width="274" alt="image" src="https://github.com/user-attachments/assets/4d01fede-6331-4bcc-b89c-da42ff6d6f8d" />

The implementation was also tested for the same jet case presented previously with max_level = 2. There are some small differences between the auxiliary mixfrac field and temperature because temperature is not conserved and Cp is a function of T. Ideally the comparison should have been done with enthalpy. However, mixfrac and T match exactly when Cp=constant.

<img width="613" alt="image" src="https://github.com/user-attachments/assets/e2980d76-cdf7-43ed-857c-960b9a0b79e6" />


